### PR TITLE
WIP API documentation

### DIFF
--- a/programs/apps/api/v1/views.py
+++ b/programs/apps/api/v1/views.py
@@ -8,10 +8,41 @@ from programs.apps.programs.models import Program
 from programs.apps.api.serializers import ProgramSerializer
 
 
-# TODO complete docstring
 class ProgramsViewSet(mixins.CreateModelMixin, mixins.ListModelMixin, viewsets.GenericViewSet):
     """
-    List / Create Programs.
+
+    **Use Cases**
+
+        List existing Programs, and create new ones.
+
+    **Example Requests**
+
+        # Return a list of programs in the system.
+        GET /api/v1/programs/
+
+        If the request is successful, the HTTP status will be 200 and the response body will
+        contain a JSON-formatted array of programs.
+
+        # Create a new program.
+        POST /api/v1/programs/
+
+        If the request is successful, the HTTP status will be 201 and the response body will
+        contain a JSON-formatted representation of the newly-created program.
+
+        Only users with global administrative rights may create programs.  POST requests from non-
+        admins will result in status 403.
+
+    **Response Values**
+
+        * id: The ID of the program.
+        * name: The user-facing display name for this Program.
+        * description: A full-length description of the Program.
+        * category: The category / type of Program.  Right now the only value allowed is 'xseries'.
+        * certificate_type: Optional certification criteria for course runs associated with this Program.
+        * status: The lifecycle status of this Program.  Right now the only value allowed is 'unpublished'.
+        * created: The date/time this Program was created.
+        * modified: The date/time this Program was last modified.
+
     """
     queryset = Program.objects.exclude(status=ProgramStatus.DELETED)
     serializer_class = ProgramSerializer

--- a/programs/settings/base.py
+++ b/programs/settings/base.py
@@ -30,6 +30,7 @@ THIRD_PARTY_APPS = (
     'rest_framework',
     'social.apps.django_app.default',
     'waffle',
+    'rest_framework_swagger',
 )
 
 PROJECT_APPS = (

--- a/programs/urls.py
+++ b/programs/urls.py
@@ -38,6 +38,7 @@ urlpatterns = [
     url(r'^health/$', core_views.health, name='health'),
     url(r'^login/$', login, name='login'),
     url(r'^logout/$', logout, name='logout'),
+    url(r'^docs/', include('rest_framework_swagger.urls')),
     url('', include('social.apps.django_app.urls', namespace='social')),
 ]
 

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -2,5 +2,7 @@ django>=1.8.4
 django-extensions==1.5.5
 django-waffle==0.10.1
 djangorestframework==3.2.3
+django-rest-swagger==0.3.4
 edx-auth-backends==0.1.3
+Markdown==2.6.2
 pytz==2015.4


### PR DESCRIPTION
@clintonb @peter-fogg @bderusha @rlucioni 

establishing api documentation, following the guideline: https://openedx.atlassian.net/wiki/display/AC/edX+REST+API+Conventions#edXRESTAPIConventions-8.Documentation

The swagger output looks nice, though it's not perfect.
The inability to create separate documentation sections for each method in a viewset is troublesome, wonder if anyone knows a workaround that doesn't involve restructuring code.