### PR TITLE
Serve a page which loads the JS API client

### DIFF
--- a/programs/templates/author.html
+++ b/programs/templates/author.html
@@ -1,0 +1,9 @@
+{# Loads the Programs administration app. Only meant for development and testing of the API client. #}
+
+{% extends 'base.html' %}
+
+{% block javascript %}
+    <script>
+        // TODO: Load client bundle here.
+    </script>
+{% endblock javascript %}


### PR DESCRIPTION
Only for development and testing of the API client. ECOM-2591. @edx/ecommerce 

@AlasdairSwan, FYI. I've left you a placeholder script tag which you can use to load the client, once available.