### PR TITLE
Update JWT settings when running in a production environment

### DIFF
--- a/programs/settings/production.py
+++ b/programs/settings/production.py
@@ -37,3 +37,9 @@ DB_OVERRIDES = dict(
 
 for override, value in DB_OVERRIDES.iteritems():
     DATABASES['default'][override] = value
+
+JWT_AUTH.update({
+    'JWT_SECRET_KEY': SOCIAL_AUTH_EDX_OIDC_SECRET,
+    'JWT_ISSUER': SOCIAL_AUTH_EDX_OIDC_URL_ROOT,
+    'JWT_AUDIENCE': SOCIAL_AUTH_EDX_OIDC_KEY,
+})


### PR DESCRIPTION
Without this, the base JWT settings are used and the configured credentials are never pulled in. ECOM-2627.

@jimabramson @feanil 