### PR TITLE
Adding the new fields in model , update the test cases accordingly.

### DIFF
--- a/CONTRIBUTORS.txt
+++ b/CONTRIBUTORS.txt
@@ -2,4 +2,5 @@ Jim Abramson <jsa@edx.org>
 Clinton Blackburn <cblackburn@edx.org>
 Alasdair Swan <aswan@edx.org>
 Renzo Lucioni <renzo@edx.org>
+Awais Qureshi <awais@edx.org>
 Ahsan Ulhaq <ahsan.ulhaq84@gmail.com>

--- a/programs/apps/api/serializers.py
+++ b/programs/apps/api/serializers.py
@@ -26,7 +26,7 @@ class ProgramCourseRunModeSerializer(serializers.ModelSerializer):
 
     class Meta(object):  # pylint: disable=missing-docstring
         model = models.ProgramCourseRunMode
-        fields = ('course_key', 'mode_slug', 'sku')
+        fields = ('course_key', 'mode_slug', 'sku', 'start_date', 'run_key')
 
 
 class CourseCodeSerializer(serializers.ModelSerializer):

--- a/programs/apps/programs/fixtures/sample_data.json
+++ b/programs/apps/programs/fixtures/sample_data.json
@@ -216,7 +216,8 @@
         "program_course_code": 1,
         "course_key": "organization-a/course-a/fall",
         "modified": "2015-10-26T20:00:47.011Z",
-        "lms_url": ""
+        "lms_url": "",
+        "start_date": "2015-10-27T16:05:11.102Z"
     },
     "model": "programs.programcourserunmode",
     "pk": 1
@@ -229,7 +230,8 @@
         "program_course_code": 1,
         "course_key": "organization-a/course-a/winter",
         "modified": "2015-10-26T20:00:51.728Z",
-        "lms_url": ""
+        "lms_url": "",
+        "start_date": "2015-10-27T16:05:11.102Z"
     },
     "model": "programs.programcourserunmode",
     "pk": 2
@@ -242,7 +244,8 @@
         "program_course_code": 2,
         "course_key": "organization-a/course-b/fall",
         "modified": "2015-10-26T20:00:57.798Z",
-        "lms_url": ""
+        "lms_url": "",
+        "start_date": "2015-10-27T16:05:11.102Z"
     },
     "model": "programs.programcourserunmode",
     "pk": 3
@@ -255,7 +258,8 @@
         "program_course_code": 2,
         "course_key": "organization-a/course-b/winter",
         "modified": "2015-10-26T20:01:04.534Z",
-        "lms_url": ""
+        "lms_url": "",
+        "start_date": "2015-10-27T16:05:11.102Z"
     },
     "model": "programs.programcourserunmode",
     "pk": 4
@@ -268,7 +272,8 @@
         "program_course_code": 3,
         "course_key": "organization-b/course-c/fall",
         "modified": "2015-10-26T20:01:41.236Z",
-        "lms_url": ""
+        "lms_url": "",
+        "start_date": "2015-10-27T16:05:11.102Z"
     },
     "model": "programs.programcourserunmode",
     "pk": 5
@@ -281,7 +286,8 @@
         "program_course_code": 3,
         "course_key": "organization-b/course-c/winter",
         "modified": "2015-10-26T20:01:56.975Z",
-        "lms_url": ""
+        "lms_url": "",
+        "start_date": "2015-10-27T16:05:11.102Z"
     },
     "model": "programs.programcourserunmode",
     "pk": 6
@@ -294,7 +300,8 @@
         "program_course_code": 4,
         "course_key": "organization-b/course-d/fall",
         "modified": "2015-10-26T20:02:08.849Z",
-        "lms_url": ""
+        "lms_url": "",
+        "start_date": "2015-10-27T16:05:11.102Z"
     },
     "model": "programs.programcourserunmode",
     "pk": 7
@@ -307,7 +314,8 @@
         "program_course_code": 4,
         "course_key": "organization-b/course-d/winter",
         "modified": "2015-10-26T20:02:22.721Z",
-        "lms_url": ""
+        "lms_url": "",
+        "start_date": "2015-10-27T16:05:11.102Z"
     },
     "model": "programs.programcourserunmode",
     "pk": 8
@@ -320,7 +328,8 @@
         "program_course_code": 5,
         "course_key": "edX/DemoX/Demo_Course",
         "modified": "2015-10-27T16:05:11.102Z",
-        "lms_url": ""
+        "lms_url": "",
+        "start_date": "2015-10-27T16:05:11.102Z"
     },
     "model": "programs.programcourserunmode",
     "pk": 9

--- a/programs/apps/programs/migrations/0004_start_date_run_key.py
+++ b/programs/apps/programs/migrations/0004_start_date_run_key.py
@@ -1,0 +1,53 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+import datetime
+
+from django.db import migrations, models
+from django.utils.timezone import utc
+
+from opaque_keys import InvalidKeyError
+from opaque_keys.edx.keys import CourseKey
+
+
+def add_run_key(apps, schema_editor):
+    """Get the value from course key and parse it through opaque keys.
+    Explicitly verifying the format here instead of model save method.
+    Otherwise any invalid record in db raises the exception.
+    """
+    ProgramCourseRunMode = apps.get_model("programs", "ProgramCourseRunMode")
+    for course_run_mode in ProgramCourseRunMode.objects.all():
+        try:
+            course_key = CourseKey.from_string(course_run_mode.course_key)
+            course_run_mode.run_key = course_key.run
+            course_run_mode.save()
+        except InvalidKeyError:
+            pass
+
+
+def remove_run_key(apps, schema_editor):
+    """Backward data migration for field 'run_key'."""
+    pass
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('programs', '0003_program_marketing_slug'),
+    ]
+
+    operations = [
+        migrations.AddField(
+            model_name='programcourserunmode',
+            name='run_key',
+            field=models.CharField(default='', help_text='A string referencing the last part of course key identifying this course run in the target LMS.', max_length=255),
+            preserve_default=False,
+        ),
+        migrations.AddField(
+            model_name='programcourserunmode',
+            name='start_date',
+            field=models.DateTimeField(default=datetime.datetime(2015, 11, 5, 7, 39, 2, 791741, tzinfo=utc), help_text='The start date of this course run in the target LMS.'),
+            preserve_default=False,
+        ),
+        migrations.RunPython(add_run_key, remove_run_key),
+    ]

--- a/programs/apps/programs/tests/factories.py
+++ b/programs/apps/programs/tests/factories.py
@@ -57,3 +57,5 @@ class ProgramCourseRunModeFactory(factory.django.DjangoModelFactory):
         model = models.ProgramCourseRunMode
 
     id = factory.Sequence(lambda n: n)
+    mode_slug = "verified"
+    sku = ''

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -9,3 +9,4 @@ django-rest-swagger==0.3.4
 edx-auth-backends==0.1.3
 Markdown==2.6.2
 pytz==2015.4
+git+https://github.com/edx/opaque-keys.git@27dc382ea587483b1e3889a3d19cbd90b9023a06#egg=opaque-keys


### PR DESCRIPTION
[ECOM-2637](https://openedx.atlassian.net/browse/ECOM-2637)

* Added two new fields in ProgramCourseRunMode model. Field names are as follows
   * **start_date**
   * **run_key**

* New Json look like
```javascript
"run_modes": [
    {
        "course_key": "edX/DemoX/Demo_Course",
        "mode_slug": "edxslug",
        "sku": "111",
        "start_date": "2015-11-04T08:46:47Z",
        "run_key": "abc"
    }
]
```
* Update the ProgramCourseRunModeFactory 
* Update the test case to reflect the new json changes.
* Add the opaque key in this repo.
* Parse the run_key from course_key in save method.
