### PR TITLE
Save ProgramOrganization with Program in creation endpoint

### DIFF
--- a/programs/apps/api/v1/views.py
+++ b/programs/apps/api/v1/views.py
@@ -1,10 +1,10 @@
 """
 Programs API views (v1).
 """
-from rest_framework import mixins, viewsets
+from rest_framework import mixins, viewsets, parsers as drf_parsers
 
 from programs.apps.programs import models
-from programs.apps.api import filters, permissions, serializers, parsers
+from programs.apps.api import filters, permissions, serializers, parsers as edx_parsers
 
 
 class ProgramsViewSet(
@@ -50,6 +50,7 @@ class ProgramsViewSet(
         * category: The category / type of Program.  Right now the only value allowed is 'xseries'.
         * status: The lifecycle status of this Program.  Right now the only value allowed is 'unpublished'.
         * marketing_slug: Slug used to generate links to the marketing site.
+        * organizations: List data containing organizations with which the program is associated.
         * created: The date/time this Program was created.
         * modified: The date/time this Program was last modified.
 
@@ -62,7 +63,7 @@ class ProgramsViewSet(
         filters.ProgramOrgKeyFilterBackend,
     )
     serializer_class = serializers.ProgramSerializer
-    parser_classes = (parsers.MergePatchParser,)
+    parser_classes = (edx_parsers.MergePatchParser, drf_parsers.JSONParser)
 
 
 class CourseCodesViewSet(mixins.ListModelMixin, viewsets.GenericViewSet):


### PR DESCRIPTION
ECOM-2727
@ahsan-ul-haq @awais786 @afeef @tasawernawaz 

Save Program with provided valid `Organization` (with its `key`) or raise validation errors.
* POST request for endpoint `/programs/` expects a nested array containing exactly one object in the `'organizations'` field, and it contains a 'key' which references an org known to the system.
* POST request for endpoint `/programs/` returns a 400, if:
 * the `key` does not match the key of an organization in the db
 * the length of the array `'organizations'` is anything other than 1