### PR TITLE
adjust JWT_LEEWAY and use custom JWT decode function

### DIFF
--- a/programs/apps/api/jwt_decode_handler.py
+++ b/programs/apps/api/jwt_decode_handler.py
@@ -1,0 +1,42 @@
+"""
+Custom JWT decoding function for django_rest_framework jwt package.
+
+Adds logging to facilitate debugging of InvalidTokenErrors.  Also
+requires "exp" and "iat" claims to be present - the base package
+doesn't expose settings to enforce this.
+"""
+import logging
+
+import jwt
+from rest_framework_jwt.settings import api_settings
+
+logger = logging.getLogger(__name__)
+
+
+def decode(token):
+    """
+    Ensure InvalidTokenErrors are logged for diagnostic purposes, before
+    failing authentication.
+    """
+
+    options = {
+        'verify_exp': api_settings.JWT_VERIFY_EXPIRATION,
+        'require_exp': True,
+        'require_iat': True,
+    }
+
+    try:
+        return jwt.decode(
+            token,
+            api_settings.JWT_SECRET_KEY,
+            api_settings.JWT_VERIFY,
+            options=options,
+            leeway=api_settings.JWT_LEEWAY,
+            audience=api_settings.JWT_AUDIENCE,
+            issuer=api_settings.JWT_ISSUER,
+            algorithms=[api_settings.JWT_ALGORITHM]
+        )
+    except jwt.InvalidTokenError as exc:
+        exc_type = u'{}.{}'.format(exc.__class__.__module__, exc.__class__.__name__)
+        logger.info("raised_invalid_token: exc_type=%r, exc_detail=%r", exc_type, exc.message)
+        raise

--- a/programs/apps/api/v1/tests/mixins.py
+++ b/programs/apps/api/v1/tests/mixins.py
@@ -27,13 +27,20 @@ class JwtMixin(object):
         token = jwt.encode(payload, secret)
         return token
 
-    def generate_id_token(self, user, admin=False, ttl=0):
+    def generate_id_token(self, user, admin=False, ttl=1, **overrides):
         """Generate a JWT id_token that looks like the ones currently
         returned by the edx oidc provider."""
 
+        payload = self.default_payload(user=user, admin=admin, ttl=ttl)
+        payload.update(overrides)
+        return self.generate_token(payload)
+
+    def default_payload(self, user, admin=False, ttl=1):
+        """Generate a bare payload, in case tests need to manipulate
+        it directly before encoding."""
         now = int(time())
 
-        return self.generate_token({
+        return {
             "iss": self.JWT_ISSUER,
             "sub": user.pk,
             "aud": self.JWT_AUDIENCE,
@@ -47,7 +54,7 @@ class JwtMixin(object):
             "name": user.full_name,
             "given_name": "",
             "family_name": "",
-        })
+        }
 
 
 class AuthClientMixin(object):

--- a/programs/settings/base.py
+++ b/programs/settings/base.py
@@ -242,6 +242,8 @@ JWT_AUTH = {
     'JWT_ISSUER': None,
     'JWT_PAYLOAD_GET_USERNAME_HANDLER': lambda d: d.get('preferred_username'),
     'JWT_AUDIENCE': None,
+    'JWT_LEEWAY': 1,
+    'JWT_DECODE_HANDLER': 'programs.apps.api.jwt_decode_handler.decode',
 }
 # END AUTHENTICATION CONFIGURATION
 


### PR DESCRIPTION
ECOM-2839

Process of elimination points to the "iat" (issued at) claim in programs JWT tokens as the cause of intermittent bursts of 401 errors.  This is the only claim with a dynamic value present in these tokens that is not present in ecom tokens (which do not experience such errors).  It's a timestamp on the generation of the JWT.   If the clock on a host where the JWT is generated is even a fraction of a second ahead of the clock on the host where it's read, the JWT can appear to have been generated in the future, and thus be considered invalid.

"Leeway" is a setting which allows the JWT library to tolerate drift between clocks on two systems - this PR changes it from the library default (zero tolerance) to 1 second.

Also in this PR are changes to require the presence of "exp" and "iat" claims, and to get more specific log messages for invalid JWT tokens in case fixing the leeway doesn't completely address the problem.

@rlucioni @cpennington @clintonb 
 