### PR TITLE
Use r.js' wrapShim option

### DIFF
--- a/build.js
+++ b/build.js
@@ -5,6 +5,8 @@
     dir: 'programs/static/build',
     removeCombined: true,
     findNestedDependencies: true,
+    // See: http://jrburke.com/2014/02/16/requirejs-2.1.11-released/.
+    wrapShim: true,
 
     // Disable all optimization. django-compressor will handle that for us.
     optimizeCss: false,


### PR DESCRIPTION
Fixes post-build issues when using an AMD-aware version of Backbone, but using shim config for scripts that depend on Backbone (e.g., Backbone.Validation). ECOM-2598.

@AlasdairSwan please review. @jimabramson FYI.