### PR TITLE
Pin astroid to 1.3.8

### DIFF
--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -1,6 +1,8 @@
 # Packages required for testing
 -r base.txt
 
+# Required by pylint. astroid 1.4.1 and pylint 1.5.0 both have bugs preventing quality checks from completing.
+astroid==1.3.8
 coverage==3.7.1
 ddt==1.0.0
 django-dynamic-fixture==1.8.5


### PR DESCRIPTION
~~Fixes new quality violations flagged by pylint, including several false positives. :unamused:~~

Required by pylint. astroid 1.4.1 and pylint 1.5.0 both have bugs preventing quality checks from completing.

@peter-fogg or @clintonb, please review. @AlasdairSwan @jimabramson FYI. This blocks builds for https://github.com/edx/programs/pull/50, https://github.com/edx/programs/pull/51, https://github.com/edx/programs/pull/52, and https://github.com/edx/programs/pull/53.