### PR TITLE
Automatically authenticate client using id token endpoint.

### DIFF
--- a/programs/static/js/models/api_config_model.js
+++ b/programs/static/js/models/api_config_model.js
@@ -1,0 +1,15 @@
+define([
+        'backbone'
+    ],
+    function( Backbone ) {
+        'use strict';
+
+        return Backbone.Model.extend({
+            defaults: {
+                'base_url': 'http://127.0.0.1:8009/api/v1/',
+                'auth_url' : 'http://127.0.0.1:8001/programs/id_token/',
+                'id_token' : ''
+            }
+        });
+    }
+);

--- a/programs/static/js/models/auto_auth_model.js
+++ b/programs/static/js/models/auto_auth_model.js
@@ -1,0 +1,84 @@
+define([
+        'backbone',
+        'jquery',
+        'js/utils/api_config'
+    ],
+    function( Backbone, $, apiConfig ) {
+        'use strict';
+
+        return Backbone.Model.extend({
+
+            /**
+             * Override Backbone.sync to seamlessly attempt (re-)authentication when necessary.
+             *
+             * If a 401 error response is encountered while making a request to the Programs,
+             * API, this wrapper will attempt to request an id token from a custom endpoint
+             * via AJAX.  Then the original request will be retried once more.
+             *
+             * Any other response than 401 on the original API request, or any error occurring
+             * on the retried API request (including 401), will be handled by the base sync
+             * implementation.
+             *
+             */
+            sync: function( method, model, options ) {
+
+                var oldError = options.error;
+
+                this._setHeaders( options );
+
+                options.error = function(xhr, textStatus, errorThrown) {
+                    if (xhr && xhr.status === 401) {
+                        // attempt auth and retry
+                        this._updateToken(function() {
+                            // restore the original error handler
+                            options.error = oldError;
+                            delete options.xhr;  // remove the failed (401) xhr from the last try.
+
+                            // update authorization header
+                            this._setHeaders( options );
+
+                            Backbone.sync.call(this, method, model, options);
+                        }.bind(this));
+                    } else if (oldError) {
+                        // fall back to the original error handler
+                        oldError.call(this, xhr, textStatus, errorThrown);
+                    }
+                }.bind(this);
+                return Backbone.sync.call(this, method, model, options);
+            },
+
+            /**
+             * Fix up headers on an imminent AJAX sync, ensuring that the JWT token is enclosed
+             * and that credentials are included when the request is being made cross-domain.
+             */
+            _setHeaders: function( ajaxOptions ) {
+                ajaxOptions.headers = _.extend ( ajaxOptions.headers || {}, {
+                    Authorization: 'JWT ' + apiConfig.get( 'id_token' )
+                });
+                ajaxOptions.xhrFields = _.extend( ajaxOptions.xhrFields || {}, {
+                    withCredentials: true
+                });
+            },
+
+            /**
+             * Fetch a new id token from the configured endpoint, update the api config,
+             * and invoke the specified callback.
+             */
+            _updateToken: function( success ) {
+
+                $.ajax({
+                    url: apiConfig.get('auth_url'),
+                    xhrFields: {
+                        withCredentials: true
+                    },
+                    crossDomain: true
+                }).done(function ( data ) {
+                    // save the newly-retrieved id token
+                    apiConfig.set( 'id_token', data.id_token );
+                }).done( success );
+
+            }
+
+        });
+    }
+);

--- a/programs/static/js/models/course_list_model.js
+++ b/programs/static/js/models/course_list_model.js
@@ -1,10 +1,10 @@
 define([
-        'backbone'
+        'js/models/auto_auth_model'
     ],
-    function( Backbone ) {
+    function( AutoAuthModel ) {
         'use strict';
 
-        return Backbone.Model.extend({
+        return AutoAuthModel.extend({
             defaults: [
                 {
                     name: 'Course 1',

--- a/programs/static/js/models/organizations_model.js
+++ b/programs/static/js/models/organizations_model.js
@@ -1,11 +1,12 @@
 define([
-        'backbone'
+        'js/utils/api_config',
+        'js/models/auto_auth_model'
     ],
-    function( Backbone ) {
+    function( apiConfig, AutoAuthModel ) {
         'use strict';
 
-        return Backbone.Model.extend({
-            urlRoot: '/api/v1/organizations/'
+        return AutoAuthModel.extend({
+            urlRoot: apiConfig.get('base_url') + 'organizations/'
         });
     }
 );

--- a/programs/static/js/models/pagination_model.js
+++ b/programs/static/js/models/pagination_model.js
@@ -1,13 +1,14 @@
 define([
-        'backbone',
         'jquery',
+        'js/utils/api_config',
+        'js/models/auto_auth_model',
         'js/collections/programs_collection'
     ],
-    function( Backbone, $, ProgramsCollection ) {
+    function( $, apiConfig, AutoAuthModel, ProgramsCollection ) {
         'use strict';
 
-        return Backbone.Model.extend({
-            urlRoot: '/api/v1/programs/',
+        return AutoAuthModel.extend({
+            urlRoot: apiConfig.get('base_url') + 'programs/',
 
             initialize: function() {
                 this.setHeaders();

--- a/programs/static/js/models/program_model.js
+++ b/programs/static/js/models/program_model.js
@@ -1,13 +1,14 @@
 define([
         'backbone',
         'jquery',
+        'js/utils/api_config',
+        'js/models/auto_auth_model',
         'jquery-cookie'
     ],
-    function( Backbone, $ ) {
+    function( Backbone, $, apiConfig, AutoAuthModel ) {
         'use strict';
 
-        return Backbone.Model.extend({
-            urlRoot: '/api/v1/programs/',
+        return AutoAuthModel.extend({
 
             // Backbone.Validation rules.
             // See: http://thedersen.com/projects/backbone-validation/#configure-validation-rules-on-the-model.
@@ -32,7 +33,7 @@ define([
             },
 
             initialize: function() {
-                this.url = this.urlRoot + this.id + '/';
+                this.url = apiConfig.get('base_url') + 'programs/' + this.id + '/';
             },
 
             validateOrganizations: function( orgArray ) {
@@ -56,9 +57,7 @@ define([
                     params = patch ? this.get('id') + '/' : '',
                     config = _.extend({ validate: true, parse: true }, {
                         type: patch ? 'PATCH' : 'POST',
-                        url: this.urlRoot + params,
-                        // The API requires a CSRF token for all POST requests using session authentication.
-                        headers: {'X-CSRFToken': $.cookie('programs_csrftoken')},
+                        url: apiConfig.get('base_url') + 'programs/' + params,
                         contentType: patch ? 'application/merge-patch+json' : 'application/json',
                         context: this,
                         // NB: setting context fails in tests
@@ -81,7 +80,7 @@ define([
             },
 
             save: function( options ) {
-                var method = '',
+                var method,
                     patch = options && options.patch ? true : false,
                     config = this.getConfig( options );
 

--- a/programs/static/js/test/specs/auto_auth_model_spec.js
+++ b/programs/static/js/test/specs/auto_auth_model_spec.js
@@ -1,0 +1,116 @@
+define([
+        'underscore',
+        'backbone',
+        'jquery',
+        'js/utils/api_config',
+        'js/models/auto_auth_model'
+    ],
+    function( _, Backbone, $, apiConfig, AutoAuthModel ) {
+        'use strict';
+
+        describe('AutoAuthModel', function () {
+
+            var model,
+                testErrorCallback,
+                fakeAjaxDeferred,
+                spyOnBackboneSync,
+                callSync,
+                checkAuthAttempted,
+                dummyModel = {'dummy': 'model'},
+                authUrl = apiConfig.get( 'auth_url' );
+
+            beforeEach( function() {
+
+                // instance under test
+                model = new AutoAuthModel();
+
+                // stand-in for the error callback a caller might pass with options to Backbone.Model.sync
+                testErrorCallback = jasmine.createSpy();
+
+                fakeAjaxDeferred = $.Deferred();
+                spyOn( $, 'ajax' ).and.returnValue( fakeAjaxDeferred );
+                return fakeAjaxDeferred;
+
+            });
+
+            spyOnBackboneSync = function( status ) {
+                // set up Backbone.sync to invoke its error callback with the desired HTTP status
+                spyOn( Backbone, 'sync' ).and.callFake( function(method, model, options) {
+                    var fakeXhr = options.xhr = { status: status };
+                    options.error(fakeXhr, 0, '');
+                });
+            };
+
+            callSync = function(options) {
+                var params,
+                    syncOptions = _.extend( { error: testErrorCallback }, options || {} );
+
+                model.sync('GET', dummyModel, syncOptions);
+
+                // make sure Backbone.sync was called with custom error handling
+                expect( Backbone.sync.calls.count() ).toEqual(1);
+                params = _.object( ['method', 'model', 'options'], Backbone.sync.calls.mostRecent().args );
+                expect( params.method ).toEqual( 'GET' );
+                expect( params.model ).toEqual( dummyModel );
+                expect( params.options.error ).not.toEqual( testErrorCallback );
+                return params;
+            };
+
+            checkAuthAttempted = function(isExpected) {
+                if (isExpected) {
+                    expect( $.ajax ).toHaveBeenCalled();
+                    expect( $.ajax.calls.mostRecent().args[0].url ).toEqual( authUrl );
+                } else {
+                    expect( $.ajax ).not.toHaveBeenCalled();
+                }
+            };
+
+            it( 'should exist', function () {
+                expect( model ).toBeDefined();
+            });
+
+            it( 'should intercept 401 errors and attempt auth', function() {
+
+                var callParams;
+
+                spyOnBackboneSync(401);
+
+                callSync();
+
+                // make sure the auth attempt was initiated
+                checkAuthAttempted(true);
+
+                // fire the success handler for the fake ajax call, with id token response data
+                fakeAjaxDeferred.resolve( {id_token: 'test-id-token'} );
+
+                // make sure the original request was retried with token, and without custom error handling
+                expect( Backbone.sync.calls.count() ).toEqual(2);
+                callParams = _.object( ['method', 'model', 'options'], Backbone.sync.calls.mostRecent().args );
+                expect( callParams.method ).toEqual( 'GET' );
+                expect( callParams.model ).toEqual( dummyModel );
+                expect( callParams.options.error ).toEqual( testErrorCallback );
+                expect( callParams.options.headers.Authorization ).toEqual( 'JWT test-id-token' );
+
+            });
+
+            it( 'should not intercept non-401 errors', function() {
+
+                spyOnBackboneSync(403);
+
+                // invoke AutoAuthModel.sync
+                callSync();
+
+                // make sure NO auth attempt was initiated
+                checkAuthAttempted(false);
+
+                // make sure the original request was not retried
+                expect( Backbone.sync.calls.count() ).toEqual(1);
+
+                // make sure the default error handling was invoked
+                expect( testErrorCallback ).toHaveBeenCalled();
+
+            });
+
+        });
+    }
+);

--- a/programs/static/js/utils/api_config.js
+++ b/programs/static/js/utils/api_config.js
@@ -1,0 +1,21 @@
+define([
+        'js/models/api_config_model'
+    ],
+    function( ApiConfigModel ) {
+        'use strict';
+
+        /**
+         * This js module implements the Singleton pattern for an instance
+         * of the ApiConfigModel Backbone model.  It returns the same shared
+         * instance of that model anywhere it is required.
+         */
+        var instance;
+
+        if (instance === undefined) {
+            instance = new ApiConfigModel();
+        }
+
+        return instance;
+
+    }
+);


### PR DESCRIPTION
ECOM-2440

Changed direction here, to avoid nasty issues with CORS and CSRF.  Now, we use a dedicated endpoint to request an id token for API requests whenever we need one, and save its value in a new model in the client app.

Depends on a new endpoint in Studio, which merged in https://github.com/edx/edx-platform/pull/10862.  Note that this works fine when the app is embedded studio; using the development version currently requires modifying Studio to whitelist the id_token endpoint with CORS. 

@rlucioni @AlasdairSwan please review.