### PR TITLE
Allow nested writes during Program updates.

### DIFF
--- a/programs/apps/programs/models.py
+++ b/programs/apps/programs/models.py
@@ -251,7 +251,7 @@ class ProgramCourseRunMode(TimeStampedModel):
                 course_key=self.course_key,
                 mode_slug=self.mode_slug,
                 sku=None,
-        ).exists():
+        ).exclude(id=self.id).exists():  # pylint: disable=no-member
             raise ValidationError(_('Duplicate course run modes are not allowed for course codes in a program.'))
 
         try:

--- a/programs/apps/programs/tests/factories.py
+++ b/programs/apps/programs/tests/factories.py
@@ -1,8 +1,11 @@
 """
 Factories for tests of Programs.
 """
+from datetime import datetime
+
 from django.utils.crypto import get_random_string
 import factory
+import pytz
 
 from programs.apps.programs import models
 from programs.apps.programs.constants import ProgramCategory, ProgramStatus
@@ -58,4 +61,4 @@ class ProgramCourseRunModeFactory(factory.django.DjangoModelFactory):
 
     id = factory.Sequence(lambda n: n)
     mode_slug = "verified"
-    sku = ''
+    start_date = datetime.now(tz=pytz.UTC)


### PR DESCRIPTION
ECOM-2210

This allows program course codes and run modes to be updated as part of a Programs PATCH request.

Note that this does not support creating program course codes based on course codes not yet known to the system.  This PR was getting big, so I plan to address that in a second, separate PR.

@rlucioni  I'm aware of a coverage gap that needs to be closed, but this is otherwise ready for review.