### PR TITLE
Reorganize dependencies to allow gulp tasks to be run during production deployments

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,16 +7,16 @@
   },
   "dependencies": {
     "bower": "^1.4.1",
-    "requirejs": "^2.1.18"
-  },
-  "devDependencies": {
+    "requirejs": "^2.1.18",
     "del": "*",
     "gulp": "^3.9.0",
     "gulp-jscs": "^3.0.1",
     "gulp-jshint": "^1.11.2",
     "gulp-sass": "*",
+    "karma": "^0.13.2"
+  },
+  "devDependencies": {
     "jasmine-core": "^2.3.4",
-    "karma": "^0.13.2",
     "karma-coverage": "^0.5.2",
     "karma-firefox-launcher": "^0.1.6",
     "karma-jasmine": "^0.3.6",


### PR DESCRIPTION
This is in response to an issue causing CI builds to fail in Jenkins, introduced by https://github.com/edx/configuration/pull/2602. The failures are due to the fact that gulp and its dependencies weren't included in Programs' production node dependencies.

@clintonb @jibsheet please review. I've manually started [a build](http://jenkins.edx.org:8080/job/ansible-provision-continuous-integration/21146/) pointing at this branch to verify that these changes fix the problem.