### PR TITLE
Correct handling of optional, empty fields

### DIFF
--- a/programs/apps/api/serializers.py
+++ b/programs/apps/api/serializers.py
@@ -95,7 +95,7 @@ class ProgramCourseRunModeSerializer(serializers.ModelSerializer):
             if isinstance(obj, models.ProgramCourseRunMode):
                 return obj.course_key, obj.mode_slug, obj.sku
             else:
-                return obj['course_key'], obj['mode_slug'], obj.get('sku')
+                return obj['course_key'], obj['mode_slug'], obj.get('sku', '')
         except (AttributeError, KeyError) as exc:
             # avoid errors when working with incomplete/invalid nested data
             raise exceptions.ValidationError(exc.message)

--- a/programs/apps/api/v1/tests/test_views.py
+++ b/programs/apps/api/v1/tests/test_views.py
@@ -183,7 +183,7 @@ class ProgramsViewTests(JwtMixin, TestCase):
                 u"id": ANY,
                 u"created": ANY,
                 u"modified": ANY,
-                u'marketing_slug': None,
+                u'marketing_slug': '',
             }
         )
 
@@ -363,7 +363,7 @@ class ProgramsViewTests(JwtMixin, TestCase):
                                 u"course_key": course_key,
                                 u"run_key": run_key,
                                 u"mode_slug": "verified",
-                                u"sku": None,
+                                u"sku": '',
                                 u"start_date": start_date.strftime(DRF_DATE_FORMAT)
                             }
                         ],
@@ -713,15 +713,15 @@ class ProgramsViewTests(JwtMixin, TestCase):
         Ensure that missing fields cause validation errors if required, and create with correct defaults otherwise.
         """
         defaults = {
-            "subtitle": None,
-            "status": ProgramStatus.UNPUBLISHED,
+            'subtitle': '',
+            'status': ProgramStatus.UNPUBLISHED,
         }
         # Create a valid organization
-        OrganizationFactory.create(key="test-org-key", display_name="test-org-display_name")
+        OrganizationFactory.create(key='test-org-key', display_name='test-org-display_name')
 
         data = self._build_post_data()
         # Add the valid organization in POST data while creating a Program
-        data["organizations"] = [{"key": "test-org-key"}]
+        data['organizations'] = [{'key': 'test-org-key'}]
 
         del data[field]
         if field in defaults:
@@ -734,7 +734,7 @@ class ProgramsViewTests(JwtMixin, TestCase):
         if expected_status == 201:
             self.assertEqual(response.data[field], defaults[field])
         else:
-            self.assertIn("field is required", response.data[field][0])
+            self.assertIn('field is required', response.data[field][0])
 
     @ddt.data(ProgramStatus.ACTIVE, ProgramStatus.RETIRED, ProgramStatus.DELETED, "", " ", "unrecognized")
     def test_create_with_invalid_status(self, status):

--- a/programs/apps/programs/fixtures/sample_data.json
+++ b/programs/apps/programs/fixtures/sample_data.json
@@ -7,7 +7,7 @@
         "name": "Test Program A",
         "created": "2015-10-26T17:52:32.861Z",
         "modified": "2015-10-26T19:59:22.716Z",
-        "marketing_slug": null
+        "marketing_slug": ""
     },
     "model": "programs.program",
     "pk": 1
@@ -20,7 +20,7 @@
         "name": "Test Program B",
         "created": "2015-10-26T19:59:03.064Z",
         "modified": "2015-10-26T19:59:18.536Z",
-        "marketing_slug": null
+        "marketing_slug": ""
     },
     "model": "programs.program",
     "pk": 2

--- a/programs/apps/programs/migrations/0006_auto_20160104_1920.py
+++ b/programs/apps/programs/migrations/0006_auto_20160104_1920.py
@@ -1,0 +1,38 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('programs', '0005_auto_20151204_2212'),
+    ]
+
+    operations = [
+        migrations.AlterField(
+            model_name='program',
+            name='marketing_slug',
+            field=models.CharField(default='', help_text='Slug used to generate links to the marketing site', max_length=255, blank=True),
+            preserve_default=False,
+        ),
+        migrations.AlterField(
+            model_name='program',
+            name='subtitle',
+            field=models.CharField(default='', help_text='A brief, descriptive subtitle for the Program.', max_length=255, blank=True),
+            preserve_default=False,
+        ),
+        migrations.AlterField(
+            model_name='programcourserunmode',
+            name='lms_url',
+            field=models.CharField(default='', help_text='The URL of the LMS where this course run / mode is being offered.', max_length=1024, blank=True),
+            preserve_default=False,
+        ),
+        migrations.AlterField(
+            model_name='programcourserunmode',
+            name='sku',
+            field=models.CharField(default='', help_text='The sku associated with this run/mode in the ecommerce system working with the target LMS.', max_length=255, blank=True),
+            preserve_default=False,
+        ),
+    ]


### PR DESCRIPTION
Avoids use of Field.null on string-based fields, as suggested by [Django's documentation](https://docs.djangoproject.com/en/1.9/ref/models/fields/#null). Enforces uniqueness of non-empty marketing slugs in code instead of at the database level. ECOM-2918.

The included migration will replace any NULL values in the affected fields with the empty string. The migration will lock affected tables when it is run, but we should be able to tolerate this. Presently, users only interact with the Programs service via the Programs API. The LMS caches the result of successful calls to the Programs API and is robust to failed calls. Worst case, a handful of users may not see XSeries messaging on their dashboard for a brief period while the migration is applied.

@jimabramson please review when you're able. @AlasdairSwan FYI.