### PR TITLE
Alasdair/ecom 3047 embedded app styling

### DIFF
--- a/programs/static/sass/_app-container.scss
+++ b/programs/static/sass/_app-container.scss
@@ -1,0 +1,10 @@
+
+// ------------------------------
+// Programs: App Container
+
+// About: styling for setting up the wrapper.
+.program-app {
+  &.layout-1q3q {
+    max-width: 1250px;
+  }
+}

--- a/programs/static/sass/_app-typography.scss
+++ b/programs/static/sass/_app-typography.scss
@@ -1,0 +1,79 @@
+
+// ------------------------------
+// Programs: App Fonts
+
+// About: resolving issue with rem units when html font-size is not 100%.
+// the issue is that the unit being used for fonts, padding and margins in the
+// UX Pattern Library (UXPL) is relative to the font-size set on the html element.
+// In studio this is set to 62.5%, however the UXPL assumes it is set to 100%. Because
+// the page in studio has other elements that are native to studio that need to be styled
+// we cannot adjust the html element's font-size on this page so I have added a Sass partial
+// that sets px values for the elements to resolve the issue. In the long-term the UXPL will
+// be added to studio and we will be able to remove this partial.
+.program-app {
+  padding-top: 20px;
+
+  .hd-3 {
+    font-size: 24px;
+  }
+
+  .copy-large {
+    font-size: 18px;
+  }
+
+  .copy-base,
+  .btn-base,
+  .field-input,
+  .field-label,
+  button {
+    font-size: 16px;
+  }
+
+  .form-group .field .field-hint,
+  .field-message {
+    font-size: 14px;
+  }
+
+  select {
+    font-size: 13px;
+  }
+
+  .input-select {
+    height: 40px;
+  }
+
+  .card {
+    padding: 20px;
+  }
+
+  .btn-base {
+    padding: 10px 20px;
+  }
+
+  fieldset {
+    padding: 5.6px 10px 12px;
+  }
+
+  .field-input,
+  .field-message.has-error {
+    padding: 10px;
+  }
+
+
+  .form-group {
+    margin-bottom: 30px;
+
+    .field {
+      margin-bottom: 40px;
+    }
+  }
+
+  p {
+    margin-bottom: 20px;
+  }
+
+  .hd-3,
+  .field-label {
+    margin-bottom: 10px;
+  }
+}

--- a/programs/static/sass/_build.scss
+++ b/programs/static/sass/_build.scss
@@ -25,18 +25,12 @@ $scope-class: 'program-app';
 // ------------------------------
 // #EXTENSIONS
 // ------------------------------
-/*
-Default views to add - being commented out and kept =
-until app styles are finalized (in case we need the partials)
-@import 'utilities';
-*/
 .#{$scope-class} {
     @import 'components';
     @import 'layouts';
     @import 'views';
     @import 'modals';
 }
-/*
-@import 'print';
-@import 'overrides';
-*/
+
+@import 'app-container';
+@import 'app-typography';


### PR DESCRIPTION
@rlucioni the issue is that the unit being used for fonts, padding and margins in the UX Pattern Library (UXPL) is relative to the font-size set on the html element. In studio this is set to 62.5%, however the UXPL assumes it is set to 100%. Because the page in studio has other elements that are native to studio that need to be styled we cannot adjust the html element's font-size on this page so I have added a Sass partial that sets px values for the elements to resolve the issue. In the long-term the UXPL will be added to studio and we will be able to remove this partial.