### PR TITLE
suppress Studio’s error popup on the initial 401

### DIFF
--- a/programs/static/js/utils/auth_utils.js
+++ b/programs/static/js/utils/auth_utils.js
@@ -26,12 +26,15 @@ define([
 
                     this._setHeaders( options );
 
+                    options.notifyOnError = false;  // suppress Studio error pop-up that will happen if we get a 401
+
                     options.error = function(xhr, textStatus, errorThrown) {
                         if (xhr && xhr.status === 401) {
                             // attempt auth and retry
                             this._updateToken(function() {
                                 // restore the original error handler
                                 options.error = oldError;
+                                options.notifyOnError = true;  // if it fails again, let Studio notify.
                                 delete options.xhr;  // remove the failed (401) xhr from the last try.
 
                                 // update authorization header


### PR DESCRIPTION
@rlucioni @AlasdairSwan FYI, yet another little fix.

This avoids 'Studio is having trouble saving your work' from popping up after a 401 that will be retried using the auth_utils.  This is not a jQuery API but something that's already implemented in Studio, see https://github.com/edx/edx-platform/blob/master/cms/static/coffee/src/main.coffee#L22

There is a theoretical corner case in which this approach may cause a legitimate error NOT to trigger the popup, however I haven't been able to create such a situation on purpose, and I'm frankly not too worried about it.