### PR TITLE
wait until initialize() to read from apiConfig.

### DIFF
--- a/programs/static/js/models/pagination_model.js
+++ b/programs/static/js/models/pagination_model.js
@@ -8,10 +8,10 @@ define([
         'use strict';
 
         return AutoAuthModel.extend({
-            urlRoot: apiConfig.get('programsApiUrl') + 'programs/',
 
             initialize: function() {
                 this.setHeaders();
+                this.urlRoot = apiConfig.get('programsApiUrl') + 'programs/';
             },
 
             getList: function() {


### PR DESCRIPTION
Fixes an issue I encountered on the sandbox, and might otherwise have bit on prod.  If the apiConfig is accessed at load time (while resolving dependencies) its default values may not yet have been overwritten by the app.

@AlasdairSwan @rlucioni FYI.