### PR TITLE
filter course runs by org key, not display_name

### DIFF
--- a/programs/static/js/collections/course_runs_collection.js
+++ b/programs/static/js/collections/course_runs_collection.js
@@ -13,7 +13,7 @@ define([
 
             initialize: function(models, options) {
                 // Ignore pagination and give me everything
-                var orgStr = options.organization.display_name,
+                var orgStr = options.organization.key,
                     queries = '?org=' + orgStr + '&username=' + apiConfig.get('username') + '&page_size=1000';
 
                 this.url = apiConfig.get('lmsBaseUrl') + 'api/courses/v1/courses/' + queries;


### PR DESCRIPTION
@AlasdairSwan @rlucioni I'm not sure how this slipped through, but the query filter we've been using was incorrect.  Please review.