### PR TITLE
Sync up JS app with Django models to allow longer program names

### DIFF
--- a/programs/static/js/models/program_model.js
+++ b/programs/static/js/models/program_model.js
@@ -15,7 +15,7 @@ define([
             validation: {
                 name: {
                     required: true,
-                    maxLength: 64
+                    maxLength: 255
                 },
                 subtitle: {
                     // The underlying Django model does not require a subtitle.

--- a/programs/static/js/test/specs/program_creator_spec.js
+++ b/programs/static/js/test/specs/program_creator_spec.js
@@ -162,7 +162,7 @@ define([
                 verifyValidation( invalidInput, 'name' );
 
                 // Name is too long.
-                invalidInput.name = 'x'.repeat(100);
+                invalidInput.name = 'x'.repeat(256);
                 verifyValidation( invalidInput, 'name' );
             });
 

--- a/programs/static/js/test/specs/program_details_spec.js
+++ b/programs/static/js/test/specs/program_details_spec.js
@@ -448,7 +448,7 @@ define([
                 });
 
                 it( 'should show error messaging if the updated field value is too long', function() {
-                    var chars65 = 'x'.repeat(65),
+                    var chars65 = 'x'.repeat(256),
                         chars256 = 'x'.repeat(256);
 
                     testInvalidUpdate( '.program-name',  chars65 );


### PR DESCRIPTION
Fixes an issue preventing existing programs with long but technically legal names from being saved.

@jimabramson @AlasdairSwan 