### PR TITLE
Make access token optional when running sync_orgs command

### DIFF
--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -8,7 +8,7 @@ djangorestframework==3.2.3
 djangorestframework-jwt==1.7.2
 django-rest-swagger==0.3.4
 edx-auth-backends==0.1.3
-edx-rest-api-client==1.4.0
+edx-rest-api-client==1.5.0
 # The package django-libsass requires libsass and libsass >= 0.10.1 validates too aggressively.
 # Pinning to 0.10.0 is a temporary workaround, but the underlying violation(s) should be fixed.
 libsass==0.10.0


### PR DESCRIPTION
Takes advantage of the client credentials grant to get an access token when one isn't provided. ECOM-3349.

@bderusha please review.