### PR TITLE
Install opaque-keys from PyPI

### DIFF
--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -8,10 +8,10 @@ djangorestframework==3.2.3
 djangorestframework-jwt==1.7.2
 django-rest-swagger==0.3.4
 edx-auth-backends==0.1.3
+edx-opaque-keys==0.2.1
 edx-rest-api-client==1.5.0
 # The package django-libsass requires libsass and libsass >= 0.10.1 validates too aggressively.
 # Pinning to 0.10.0 is a temporary workaround, but the underlying violation(s) should be fixed.
 libsass==0.10.0
 Markdown==2.6.2
 pytz==2015.4
-git+https://github.com/edx/opaque-keys.git@27dc382ea587483b1e3889a3d19cbd90b9023a06#egg=opaque-keys


### PR DESCRIPTION
The opaque-keys package is available on PyPI. FYI @schenedx @jimabramson @clintonb 