### PR TITLE
ECOM-3198 Add a new set of sizes to the banner image for display

### DIFF
--- a/programs/apps/programs/migrations/0007_auto_20160318_1859.py
+++ b/programs/apps/programs/migrations/0007_auto_20160318_1859.py
@@ -16,7 +16,7 @@ class Migration(migrations.Migration):
         migrations.AddField(
             model_name='program',
             name='banner_image',
-            field=programs.apps.programs.fields.ResizingImageField(path_template=b'program/banner/{uuid}', null=True, upload_to=b'', sizes=[(1440, 480), (480, 160), (360, 120), (180, 60)], blank=True),
+            field=programs.apps.programs.fields.ResizingImageField(path_template=b'program/banner/{uuid}', null=True, upload_to=b'', sizes=[(1440, 480), (726, 242), (435, 145), (348, 116)], blank=True),
         ),
         migrations.AddField(
             model_name='program',

--- a/programs/apps/programs/models.py
+++ b/programs/apps/programs/models.py
@@ -73,7 +73,7 @@ class Program(TimeStampedModel):
 
     banner_image = ResizingImageField(
         path_template='program/banner/{uuid}',
-        sizes=[(1440, 480), (480, 160), (360, 120), (180, 60)],
+        sizes=[(1440, 480), (726, 242), (435, 145), (348, 116)],
         null=True,
         blank=True,
     )


### PR DESCRIPTION
The original size does not fit the dimensions of the program cards well.
Tweak the sizes of the banner images so the program cards looks better