### PR TITLE
Capture acceptance test results in an xunit.xml file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -38,6 +38,7 @@ htmlcov
 .tox
 nosetests.xml
 unittests.xml
+acceptance_tests/xunit.xml
 
 ### Internationalization artifacts
 *.mo

--- a/Makefile
+++ b/Makefile
@@ -64,7 +64,7 @@ validate_js:
 	$(NODE_BIN)/gulp jscs
 
 accept:
-	nosetests --with-ignore-docstrings -v acceptance_tests
+	nosetests --with-ignore-docstrings -v acceptance_tests --with-xunit --xunit-file=acceptance_tests/xunit.xml
 
 validate: test quality validate_js
 


### PR DESCRIPTION
This will allow test results to be more easily consumed by:
* CI infrastructure
* Developers who want to understand results
* Logging infrastructure we use wherein we can roll together test results across repos