### PR TITLE
Upgrade Django to 1.8.12

### DIFF
--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -1,5 +1,5 @@
 boto==2.39.0
-django==1.8.11
+django==1.8.12
 django_compressor==1.5
 django-cors-headers==1.1.0
 django-extensions==1.5.5


### PR DESCRIPTION
ECOM-4248.

@clintonb @schenedx, FYI. 1.8.12 was released on April 1 and contains bug fixes. [Release notes](https://docs.djangoproject.com/es/1.9/releases/1.8.12/).