### PR TITLE
Updated edx-auth-backends to 0.2.1

### DIFF
--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -9,7 +9,7 @@ django-waffle==0.10.1
 djangorestframework==3.2.3
 djangorestframework-jwt==1.8.0
 django-rest-swagger==0.3.4
-edx-auth-backends==0.1.3
+edx-auth-backends==0.2.1
 edx-drf-extensions==0.4.1
 edx-opaque-keys==0.2.1
 edx-rest-api-client==1.5.0


### PR DESCRIPTION
This version of the package stores the token_type in the User.extra_data.

ECOM-4263