### PR TITLE
Fix overly specific get_or_create preventing org sync

### DIFF
--- a/programs/apps/programs/management/commands/sync_orgs.py
+++ b/programs/apps/programs/management/commands/sync_orgs.py
@@ -52,14 +52,16 @@ class Command(BaseCommand):
 
             for org in orgs:
                 if org['active']:
-                    fields = {
-                        'key': org['short_name'],
-                        'display_name': org['name']
-                    }
+                    obj, created = Organization.objects.get_or_create(
+                        key=org['short_name'],
+                        defaults={'display_name': org['name']}
+                    )
 
-                    __, created = Organization.objects.get_or_create(**fields)
                     if created:
                         self.new_org_count += 1
+                    elif obj.display_name != org['name']:
+                        obj.display_name = org['name']
+                        obj.save()
 
             if data['next']:
                 self.page += 1

--- a/programs/apps/programs/tests/test_sync_orgs.py
+++ b/programs/apps/programs/tests/test_sync_orgs.py
@@ -2,6 +2,7 @@
 import itertools
 import json
 import math
+import random
 
 import ddt
 from django.conf import settings
@@ -114,6 +115,14 @@ class SyncOrgsTests(TestCase):
             )
 
         initial_count = Organization.objects.count()
+
+        # Change the display name of an existing record to verify that modified
+        # display names can by synced without issue.
+        org = Organization.objects.get(key=self.KEY.format(1))
+        exploded = list(org.display_name)
+        random.shuffle(exploded)
+        org.display_name = ''.join(exploded)
+        org.save()
 
         self._mock_oauth2_provider()
         self._mock_organizations_api()


### PR DESCRIPTION
In case their display name has changed, orgs should initially be looked up by key. The display name can be updated separately.

@schenedx or @jimabramson, could I get a review from one of you? @jibsheet FYI, this will fix the error we observed.