### PR TITLE
ECOM-3237 Default Program Images for Programs Listing Page

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -18,7 +18,7 @@ help:
 	@echo "  pull_translations          pull translations from Transifex"
 	@echo "  push_translations          push source translation files (.po) from Transifex"
 	@echo "  quality                    run PEP8 and Pylint"
-	@echo "  make accept                run acceptance tests"
+	@echo "  accept                     run acceptance tests"
 	@echo "  requirements               install requirements for local development"
 	@echo "  requirements.js            install JavaScript requirements for local development"
 	@echo "  serve                      serve Programs at 0.0.0.0:8004"

--- a/programs/apps/programs/admin.py
+++ b/programs/apps/programs/admin.py
@@ -3,6 +3,7 @@ from django import forms
 from django.contrib import admin
 from opaque_keys import InvalidKeyError
 from opaque_keys.edx.keys import CourseKey
+from solo.admin import SingletonModelAdmin
 
 from programs.apps.programs import models
 from programs.apps.programs.image_helpers import validate_image_type, validate_image_size
@@ -83,6 +84,7 @@ class ProgramCourseRunModeForm(forms.ModelForm):
     """Model form for ProgramCourseCode model. Adding custom validation for
     course key format at form level.
     """
+
     def clean_course_key(self):
         """Clean the course key to make sure format is valid."""
         course_key = self.cleaned_data['course_key']
@@ -117,3 +119,4 @@ admin.site.register(models.ProgramOrganization, ProgramOrganizationAdmin)
 admin.site.register(models.CourseCode, CourseCodeAdmin)
 admin.site.register(models.ProgramCourseCode, ProgramCourseCodeAdmin)
 admin.site.register(models.ProgramCourseRunMode, ProgramCourseRunModeAdmin)
+admin.site.register(models.ProgramDefault, SingletonModelAdmin)

--- a/programs/apps/programs/migrations/0010_programdefault.py
+++ b/programs/apps/programs/migrations/0010_programdefault.py
@@ -1,0 +1,25 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import migrations, models
+import programs.apps.programs.fields
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('programs', '0009_make_program_uuid_unique'),
+    ]
+
+    operations = [
+        migrations.CreateModel(
+            name='ProgramDefault',
+            fields=[
+                ('id', models.AutoField(verbose_name='ID', serialize=False, auto_created=True, primary_key=True)),
+                ('banner_image', programs.apps.programs.fields.ResizingImageField(sizes=[(1440, 480), (726, 242), (435, 145), (348, 116)], path_template=b'program/banner/default', upload_to=b'', max_length=1000, blank=True, null=True)),
+            ],
+            options={
+                'abstract': False,
+            },
+        ),
+    ]

--- a/programs/apps/programs/models.py
+++ b/programs/apps/programs/models.py
@@ -8,9 +8,13 @@ from django.utils.translation import ugettext_lazy as _
 from django_extensions.db.models import TimeStampedModel
 from opaque_keys import InvalidKeyError
 from opaque_keys.edx.keys import CourseKey
+from solo.models import SingletonModel
 
 from programs.apps.programs import constants
 from programs.apps.programs.fields import ResizingImageField
+
+
+RESIZABLE_IMAGE_SIZES = [(1440, 480), (726, 242), (435, 145), (348, 116)]
 
 
 def _choices(*values):
@@ -74,7 +78,7 @@ class Program(TimeStampedModel):
 
     banner_image = ResizingImageField(
         path_template='program/banner/{uuid}',
-        sizes=[(1440, 480), (726, 242), (435, 145), (348, 116)],
+        sizes=RESIZABLE_IMAGE_SIZES,
         null=True,
         blank=True,
         max_length=1000,
@@ -275,3 +279,19 @@ class ProgramCourseRunMode(TimeStampedModel):
             raise ValidationError(_("Invalid course key."))
 
         return super(ProgramCourseRunMode, self).save()
+
+
+class ProgramDefault(SingletonModel):
+    """
+    Model used to store default program configuration.
+    This includes a default, resizable banner image which is
+    used if a given program has not specified its own banner image.
+    This model is a singleton - only one instance exists.
+    """
+    banner_image = ResizingImageField(
+        path_template='program/banner/default',
+        sizes=RESIZABLE_IMAGE_SIZES,
+        null=True,
+        blank=True,
+        max_length=1000,
+    )

--- a/programs/apps/programs/tests/factories.py
+++ b/programs/apps/programs/tests/factories.py
@@ -62,3 +62,10 @@ class ProgramCourseRunModeFactory(factory.django.DjangoModelFactory):
     id = factory.Sequence(lambda n: n)
     mode_slug = "verified"
     start_date = datetime.now(tz=pytz.UTC)
+
+
+class ProgramDefaultFactory(factory.django.DjangoModelFactory):
+    class Meta(object):
+        model = models.ProgramDefault
+
+    id = factory.Sequence(lambda n: n)

--- a/programs/apps/programs/tests/helpers.py
+++ b/programs/apps/programs/tests/helpers.py
@@ -7,10 +7,12 @@ TODO:
     and could ultimately be moved (with related modules) into a shared utility package.
 """
 from contextlib import contextmanager
+from cStringIO import StringIO
 import os
 from tempfile import NamedTemporaryFile
 
-from django.core.files.uploadedfile import UploadedFile
+from django.core.files.uploadedfile import UploadedFile, SimpleUploadedFile
+
 import piexif
 from PIL import Image
 
@@ -60,3 +62,13 @@ def make_uploaded_file(content_type, *a, **kw):
             content_type=content_type,
             size=os.path.getsize(image_file.name),
         )
+
+
+def make_banner_image_file(name):
+    """
+    Helper to generate values for program banner_image
+    """
+    image = Image.new('RGB', (1440, 900), 'green')
+    sio = StringIO()
+    image.save(sio, format='JPEG')
+    return SimpleUploadedFile(name, sio.getvalue(), content_type='image/jpeg')

--- a/programs/settings/base.py
+++ b/programs/settings/base.py
@@ -25,6 +25,7 @@ INSTALLED_APPS = (
     'django.contrib.messages',
     'django.contrib.staticfiles',
     'corsheaders',
+    'solo',
 )
 
 THIRD_PARTY_APPS = (

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -4,6 +4,7 @@ django_compressor==1.5
 django-cors-headers==1.1.0
 django-extensions==1.5.5
 django-libsass==0.4
+django-solo==1.1.2
 django-storages==1.4
 django-waffle==0.10.1
 djangorestframework==3.2.3


### PR DESCRIPTION
@rlucioni Please review

Tested using django admin:

- Created a default program banner image within the DefaultProgramValue object
-- Made sure the API returned the default image
-- Made sure when a program already have the banner image defined, the program defined banner image urls are returned
- Try to add a new DefaultProgramValue object and made sure the error is handled gracefully in django admin