### PR TITLE
ECOM-4403 fix the bug with clean stale images

### DIFF
--- a/programs/apps/programs/fields.py
+++ b/programs/apps/programs/fields.py
@@ -115,7 +115,7 @@ class ResizingImageFieldFile(ImageFieldFile):
         ordered_groups = OrderedDict(
             sorted(
                 groups.items(),
-                key=lambda t: self.storage.created_time(os.path.join(dir_, t[0])),
+                key=lambda t: self.storage.modified_time(os.path.join(dir_, t[0])),
                 reverse=True
             )
         )

--- a/programs/apps/programs/tests/test_fields.py
+++ b/programs/apps/programs/tests/test_fields.py
@@ -139,7 +139,7 @@ class ResizingImageFieldFileTestCase(TestCase):
         with mock.patch.object(field_value, 'storage') as mock_storage:
             mock_storage.listdir = mock.Mock(return_value=([], listdir_results))
             mock_storage.delete = mock.Mock(return_value=None)
-            mock_storage.created_time = mock.Mock(side_effect=lambda n: historical_ctimes[n])
+            mock_storage.modified_time = mock.Mock(side_effect=lambda n: historical_ctimes[n])
             field_value.clean_stale_images(keep_previous=keep_previous)
 
         expected_deleted_paths = ['{}/{}'.format(self.field.path_template, name) for name in expected_deleted_names]


### PR DESCRIPTION
The line in PR https://github.com/edx/programs/pull/128/files#diff-b4b27d9e5b70b25e71fa7e0fd5762a21R118 is problematic if we use S3BotoStorageFile implementation of the Django Storage API. That implementation do not have a "created_time". Instead, it has the "modified_time" property for this purpose.

This fixes that

@rlucioni Please review