### PR TITLE
ECOM-4309 update the Organization model to remove the display_name unique constraint

### DIFF
--- a/programs/apps/programs/migrations/0011_auto_20160510_1524.py
+++ b/programs/apps/programs/migrations/0011_auto_20160510_1524.py
@@ -1,0 +1,19 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('programs', '0010_programdefault'),
+    ]
+
+    operations = [
+        migrations.AlterField(
+            model_name='organization',
+            name='display_name',
+            field=models.CharField(help_text='The display name of this organization.', max_length=128),
+        ),
+    ]

--- a/programs/apps/programs/models.py
+++ b/programs/apps/programs/models.py
@@ -119,7 +119,6 @@ class Organization(TimeStampedModel):
     )
     display_name = models.CharField(
         help_text=_('The display name of this organization.'),
-        unique=True,
         max_length=128,
     )
     programs = models.ManyToManyField(Program, related_name='organizations', through='ProgramOrganization')


### PR DESCRIPTION
@rlucioni Please review
@AlasdairSwan FYI

Tested locally:
 - Made sure with a dupe long name in the LMS organization data, the sync command fails before the change
 - After the change, make sure the sync command succeeds