### PR TITLE
Remove django-waffle (unused)

### DIFF
--- a/programs/settings/base.py
+++ b/programs/settings/base.py
@@ -31,7 +31,6 @@ INSTALLED_APPS = (
 THIRD_PARTY_APPS = (
     'rest_framework',
     'social.apps.django_app.default',
-    'waffle',
     'rest_framework_swagger',
     'compressor',
 )
@@ -56,7 +55,6 @@ MIDDLEWARE_CLASSES = (
     'django.contrib.messages.middleware.MessageMiddleware',
     'django.middleware.clickjacking.XFrameOptionsMiddleware',
     'social.apps.django_app.middleware.SocialAuthExceptionMiddleware',
-    'waffle.middleware.WaffleMiddleware',
 )
 
 ROOT_URLCONF = 'programs.urls'

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -6,7 +6,6 @@ django-extensions==1.5.5
 django-libsass==0.4
 django-solo==1.1.2
 django-storages==1.4
-django-waffle==0.10.1
 djangorestframework==3.2.3
 djangorestframework-jwt==1.8.0
 django-rest-swagger==0.3.4


### PR DESCRIPTION
I was going to upgrade to 0.11.1 but then realized this project doesn't actually use Waffle.

@edx/ecommerce 