### PR TITLE
Make user creation during JWT authentication more robust

### DIFF
--- a/programs/apps/api/v1/views.py
+++ b/programs/apps/api/v1/views.py
@@ -3,8 +3,10 @@ Programs API views (v1).
 """
 import warnings
 
+from django.db import transaction
 from django.db.models import Prefetch
 from django.db.models.functions import Lower
+from django.utils.decorators import method_decorator
 from rest_framework import (
     decorators,
     mixins,
@@ -94,6 +96,10 @@ class ProgramsViewSet(
     )
     serializer_class = serializers.ProgramSerializer
     parser_classes = (edx_parsers.MergePatchParser, drf_parsers.JSONParser)
+
+    @method_decorator(transaction.non_atomic_requests)
+    def dispatch(self, request, *args, **kwargs):
+        return super(ProgramsViewSet, self).dispatch(request, *args, **kwargs)
 
     def get_queryset(self):
         """Perform eager loading of data to prevent a cascade of performance-degrading queries."""


### PR DESCRIPTION
Even with MySQL set to use the READ COMMITTED isolation level, get_or_create during JWT authentication sometimes raises an IntegrityError and the user in question fails to appear in a subsequent get() call. These changes address this issue by disabling atomic requests for the programs API and introducing more robust retry logic meant to prevent IntegrityErrors from causing authenticated requests to fail. ECOM-4506.

@cpennington please review. @mikedikan @schenedx FYI.