### PR TITLE
Revert "Fix CSS compilation"

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,8 +12,7 @@
     "gulp": "^3.9.0",
     "gulp-jscs": "^3.0.1",
     "gulp-jshint": "^1.11.2",
-    "gulp-sass": "^2.3.2",
-    "node-sass": "3.4.2",
+    "gulp-sass": "*",
     "karma": "^0.13.2"
   },
   "devDependencies": {


### PR DESCRIPTION
This reverts commit 8e18bca1dee2791c5408616a168ff84960d003bc. node-sass@3.4.2 works with the latest node LTS (v4.4.x), but not the latest, unstable node (v6.x.x). Programs may be installed in places where the node version is unpinned and defaults to 6.x.x.

@efischer19 