### PR TITLE
Unpack media storage settings when applying config overrides

### DIFF
--- a/programs/settings/production.py
+++ b/programs/settings/production.py
@@ -23,7 +23,7 @@ LOGGING = get_logger_config()
 
 # Keep track of the names of settings that represent dicts. Instead of overriding the values in base.py,
 # the values read from disk should UPDATE the pre-configured dicts.
-DICT_UPDATE_KEYS = ('JWT_AUTH', 'MEDIA_STORAGE_BACKEND',)
+DICT_UPDATE_KEYS = ('JWT_AUTH',)
 
 # This may be overridden by the YAML in PROGRAMS_CFG, but it should be here as a default.
 MEDIA_STORAGE_BACKEND = {}
@@ -41,6 +41,9 @@ with open(CONFIG_FILE) as f:
             vars()[key].update(value)
 
     vars().update(config_from_yaml)
+
+    # Unpack media storage settings.
+    vars().update(MEDIA_STORAGE_BACKEND)
 
 DB_OVERRIDES = dict(
     PASSWORD=environ.get('DB_MIGRATION_PASS', DATABASES['default']['PASSWORD']),


### PR DESCRIPTION
@e0d @maxrothman @clintonb 

This was removed in https://github.com/edx/programs/commit/ec2a6cd8a01bff561e8d0b61988be68c8ea1d949#diff-2ca989f014687f3223a751f4dbc2756eL34.