### PR TITLE
Remove django-compressor

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -30,7 +30,7 @@ clean:
 	coverage erase
 
 requirements:
-	pip install -qr requirements/local.txt --exists-action w
+	pip install -r requirements/local.txt
 
 test: clean
 	REUSE_DB=1 coverage run ./manage.py test programs --settings=programs.settings.test
@@ -42,7 +42,6 @@ quality:
 
 serve:
 	python manage.py runserver 0.0.0.0:8004
-
 
 accept:
 	nosetests --with-ignore-docstrings -v acceptance_tests --with-xunit --xunit-file=acceptance_tests/xunit.xml

--- a/programs/settings/base.py
+++ b/programs/settings/base.py
@@ -32,7 +32,6 @@ THIRD_PARTY_APPS = (
     'rest_framework',
     'social.apps.django_app.default',
     'rest_framework_swagger',
-    'compressor',
     'release_util',
 )
 
@@ -128,10 +127,7 @@ STATIC_URL = '/static/'
 STATICFILES_FINDERS = (
     'django.contrib.staticfiles.finders.FileSystemFinder',
     'django.contrib.staticfiles.finders.AppDirectoriesFinder',
-    'compressor.finders.CompressorFinder',
 )
-
-COMPRESS_CSS_FILTERS = ['compressor.filters.css_default.CssAbsoluteFilter']
 # END STATIC FILE CONFIGURATION
 
 

--- a/programs/settings/production.py
+++ b/programs/settings/production.py
@@ -10,15 +10,6 @@ TEMPLATE_DEBUG = DEBUG
 
 ALLOWED_HOSTS = ['*']
 
-# Enable offline compression of CSS/JS
-COMPRESS_ENABLED = True
-COMPRESS_OFFLINE = True
-
-# Minify CSS
-COMPRESS_CSS_FILTERS += [
-    'compressor.filters.cssmin.CSSMinFilter',
-]
-
 LOGGING = get_logger_config()
 
 # Keep track of the names of settings that represent dicts. Instead of overriding the values in base.py,

--- a/programs/settings/test.py
+++ b/programs/settings/test.py
@@ -49,12 +49,3 @@ JWT_AUTH.update({
 # END AUTHENTICATION
 
 ORGANIZATIONS_API_URL_ROOT = 'http://test-lms.com/api/organizations/v0/'
-
-# Enable offline compression of CSS/JS
-COMPRESS_ENABLED = True
-COMPRESS_OFFLINE = True
-
-# Minify CSS
-COMPRESS_CSS_FILTERS += [
-    'compressor.filters.cssmin.CSSMinFilter',
-]

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -1,9 +1,7 @@
 boto==2.39.0
 django==1.8.14
-django_compressor==1.5
 django-cors-headers==1.1.0
 django-extensions==1.5.5
-django-libsass==0.4
 django-solo==1.1.2
 django-storages==1.4
 djangorestframework==3.2.3
@@ -14,9 +12,6 @@ edx-django-release-util==0.0.3
 edx-drf-extensions==1.1.1
 edx-opaque-keys==0.2.1
 edx-rest-api-client==1.5.0
-# The package django-libsass requires libsass and libsass >= 0.10.1 validates too aggressively.
-# Pinning to 0.10.0 is a temporary workaround, but the underlying violation(s) should be fixed.
-libsass==0.10.0
 Markdown==2.6.2
 piexif==1.0.3
 Pillow==3.1.1


### PR DESCRIPTION
We no longer use this tool. Counterpart to https://github.com/edx/configuration/pull/3267.

@schenedx @mikedikan please review.