### PR TITLE
Case category constants for display

### DIFF
--- a/programs/apps/programs/constants.py
+++ b/programs/apps/programs/constants.py
@@ -7,14 +7,14 @@ from __future__ import unicode_literals
 class ProgramCategory(object):
     """Allowed values for Program.category"""
 
-    XSERIES = "xseries"
-    MICROMASTERS = "micromasters"
+    XSERIES = 'XSeries'
+    MICROMASTERS = 'MicroMasters'
 
 
 class ProgramStatus(object):
     """Allowed values for Program.status"""
 
-    UNPUBLISHED = "unpublished"
-    ACTIVE = "active"
-    RETIRED = "retired"
-    DELETED = "deleted"
+    UNPUBLISHED = 'unpublished'
+    ACTIVE = 'active'
+    RETIRED = 'retired'
+    DELETED = 'deleted'

--- a/programs/apps/programs/migrations/0013_auto_20160725_2147.py
+++ b/programs/apps/programs/migrations/0013_auto_20160725_2147.py
@@ -1,0 +1,19 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('programs', '0012_auto_20160719_1523'),
+    ]
+
+    operations = [
+        migrations.AlterField(
+            model_name='program',
+            name='category',
+            field=models.CharField(help_text='The category / type of Program.', max_length=32, choices=[('XSeries', 'XSeries'), ('MicroMasters', 'MicroMasters')]),
+        ),
+    ]


### PR DESCRIPTION
Ultimately, these will be replaced by a proper ProgramCategory model. In the meantime, correcting the casing here does away with the need to force consumers of this API to parse and hardcode references to these categories. Django doesn't enforce choices on a database level; the migration exists to appease Django 1.8's migrations framework. Part of ECOM-5018.

Since we intend to roll this into the catalog, I realize that we should generally avoid making changes to this code. However, I think the benefits of doing this make this case an exception. I'm going to create corresponding PRs for Studio and the LMS.

@mikedikan @schenedx please review. @bderusha @clintonb FYI.