### PR TITLE
Change edx-django-release-util version.

### DIFF
--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -8,7 +8,7 @@ djangorestframework==3.2.3
 djangorestframework-jwt==1.8.0
 django-rest-swagger==0.3.4
 edx-auth-backends==0.2.3
-edx-django-release-util==0.1.0
+edx-django-release-util==0.1.1
 edx-drf-extensions==1.1.1
 edx-opaque-keys==0.2.1
 edx-rest-api-client==1.5.0


### PR DESCRIPTION
Change the required version of edx-django-release-util to 0.1.1.

@edx/ecommerce  Please review and tag appropriate parties.