### PR TITLE
Update new relic agent to v2.70

### DIFF
--- a/requirements/optional.txt
+++ b/requirements/optional.txt
@@ -1,2 +1,2 @@
 # Optional packages
-newrelic==2.56.0.42
+newrelic==2.70.0.51


### PR DESCRIPTION
This update specifically resolves a bunch of "data collector is not contactable" errors spamming our logs due to the agent keeping connections open too long and erroring when they are closed on it.

FYI @edx/ecommerce 

