### PR TITLE
Use a 16.04 docker image to test

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,18 +1,20 @@
 language: python
 python:
   - "2.7"
-sudo: false
+sudo: required
+services:
+  - docker
 
 cache:
   - pip
+
 before_install:
-  - "export DISPLAY=:99.0"
-  - "sh -e /etc/init.d/xvfb start"
-install:
-  - pip install -U pip wheel codecov
-  - make requirements
+  - docker-compose -f docker-compose-travis.yml up -d
+
 script:
-  - make validate_translations
-  - make validate
+  - docker exec programs_testing /edx/app/programs/programs/.travis/run_tests.sh
+
 after_success:
+  - pip install -U codecov
+  - docker exec programs_testing /edx/app/programs/programs/.travis/run_coverage.sh
   - codecov

--- a/.travis/run_coverage.sh
+++ b/.travis/run_coverage.sh
@@ -1,0 +1,4 @@
+#!/bin/bash -xe
+. /edx/app/programs/venvs/programs/bin/activate
+cd /edx/app/programs/programs
+coverage xml

--- a/.travis/run_tests.sh
+++ b/.travis/run_tests.sh
@@ -1,0 +1,7 @@
+#!/bin/bash -xe
+. /edx/app/programs/venvs/programs/bin/activate
+cd /edx/app/programs/programs
+pip install -U pip wheel
+make requirements
+make validate_translations
+make validate

--- a/docker-compose-travis.yml
+++ b/docker-compose-travis.yml
@@ -1,0 +1,16 @@
+# This is only currently used by Travis for testing
+version: "2"
+
+services:
+  programs:
+    image: edxops/programs:latest
+
+    container_name: programs_testing
+    volumes:
+      - .:/edx/app/programs/programs
+      - $HOME/.cache/pip:/edx/app/programs/.cache/pip
+    # The docker container produced from configuration.git does not currently
+    # run and expose a port for programs.  This means that we need to run some
+    # command that keeps the programs container alive while we run tests on it.
+    # We have not yet standardized on an init replacement which could be used instead.
+    command: tail -f /dev/null


### PR DESCRIPTION
This is not 100% yet - it doesn't pass down the token for codecov, I need to find where we set it and pass it into the docker container.

There are about 7 ways to skin the container build/run cat, but I think this is simple if a bit inelegant.
I'll rename the shell script, and Ed and I discussed possibly generating it from the travis.yml runtime instead.  

Just wanted to get any initial thoughts/concerns from @e0d @clintonb @rlucioni 